### PR TITLE
Remove invalid ruby 2.6 code

### DIFF
--- a/lib/best_in_place/check_version.rb
+++ b/lib/best_in_place/check_version.rb
@@ -2,7 +2,7 @@ module BestInPlace
   module CheckVersion
     if Rails::VERSION::STRING < "3.1"
       raise "This version of Best in Place is intended to be used for Rails >= 3.1. If you want to use it with Rails 3.0 or lower, please use the rails-3.0 branch."
-      return
+
     end
   end
 end


### PR DESCRIPTION
This module level return is invalid syntax in ruby 2.6. I don't believe that it will effect behavior even if we where on a pre-rails 3.1 version. However, since we are past rails 3.1 we are sure to not see any change.